### PR TITLE
Add support for the RS PRO RSPD3303X-E

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@
 Siglent SPD3303X/-E are programmable lab bench power supplies.
 They can be accessed remotely via a VISA interface.
 
-This packet provides a python API for convenient remote programming of the Device via Ethernet/USB.
+This package provides a Python API for convenient remote programming of the Device via Ethernet/USB.
 Currently, the module supports setting voltage and current limits, measuring voltage and current and enabling or disabling individual outputs.
 
 The module also provides a CLI tool to conveniently control the power supply from the command line.
+
+Also supports the very similar RS PRO RSPD3303X-E.
 
 ## Examples
 

--- a/spd3303x/__init__.py
+++ b/spd3303x/__init__.py
@@ -13,6 +13,17 @@ logger.setLevel(logging.DEBUG)
 
 class SPD3303X(object):
 
+    KNOWN_MODELS = [
+        "SPD3303X",
+        "SPD3XIDD5R7170",
+    ]
+
+    MANUFACTURERS = {
+        "SPD3303X": "Siglent",
+        "SPD3XIDD5R7170": "[RS PRO]",
+    }
+
+
     @classmethod
     def usb_device(cls, visa_rscr: str=None):
         return USBDevice(visa_rscr)
@@ -57,9 +68,16 @@ class SPD3303X(object):
         except pyvisa.errors.VisaIOError:
             self._inst.close()
             raise
-        mnf,model,_,_,_ = dsc.split(",")
+        identity_items = dsc.split(",")
+        if len(identity_items) == 3:
+            # RS PRO RSPD3303X-E ?
+            model, _, _= dsc.split(",")
+            mnf = self.MANUFACTURERS.get(model, "[Unknown]")
+        else:
+            # Proper Siglent device probably.
+            mnf, model,_,_,_ = identity_items
         logger.debug(f"Discovered {model} by {mnf}")
-        if model!="SPD3303X":
+        if model not in self.KNOWN_MODELS:
             raise Exception(f"Device {model} not supported")
         self.CH1 = SPD3303X.ControlledChannel(1, self)
         self.CH2 = SPD3303X.ControlledChannel(2, self)

--- a/spd3303x/__init__.py
+++ b/spd3303x/__init__.py
@@ -15,11 +15,14 @@ class SPD3303X(object):
 
     KNOWN_MODELS = [
         "SPD3303X",
+        "SPD3303X-E",
         "SPD3XIDD5R7170",
     ]
 
     MANUFACTURERS = {
         "SPD3303X": "Siglent",
+        "SPD3303X-E": "Siglent",
+        # This one is called RSPD3303X-E by RS PRO.
         "SPD3XIDD5R7170": "[RS PRO]",
     }
 


### PR DESCRIPTION
This is a re-badged SPD3303X-E but it displays different information in the `*IDN?` query.

[RS PRO RSPD3303X-E](https://uk.rs-online.com/web/p/bench-power-supplies/1236468)