### PR TITLE
Address removal of xdrlib from standard library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,15 @@ HERE = pathlib.Path(__file__).parent
 # The text of the README file
 README = (HERE / "README.md").read_text()
 
-requirements = ["numpy", "pyvisa-py", "click", "python-vxi11", "zeroconf", "psutil"]
+requirements = [
+    "numpy",
+    "pyvisa-py",
+    "click",
+    "python-vxi11",
+    "zeroconf",
+    "psutil",
+    "standard-xdrlib; python_version>='3.13'"
+]
 
 setup(
     name="spd3303x",

--- a/spd3303x/__init__.py
+++ b/spd3303x/__init__.py
@@ -1,7 +1,6 @@
 import pyvisa
 import numpy as np
 import time
-import xdrlib
 import logging
 import socket
 import vxi11


### PR DESCRIPTION
As mentioned in #4, xdrlib was removed from the standard library in Python 3.13, breaking spd3303x in newer Python versions. 

I removed the unused xdrlib import from spd3303x and that caused no problems. However, spd3303x has the dependency [python-vxi11](https://github.com/python-ivi/python-vxi11), which uses xdrlib extensively and appears to be unmaintained. [An issue](https://github.com/python-ivi/python-vxi11/issues/49) on vxi11 suggests using https://github.com/youknowone/python-deadlib to provide a fork of xdrlib to vxi11 ourselves.

Using that suggested xdrlib fork lets spd3303x work in Python 3.13 now:

**3.11**
```
============================= test session starts ==============================
platform linux -- Python 3.11.2, pytest-8.4.1, pluggy-1.6.0
rootdir: /home/teddy/repos/python-spd3303x
configfile: pyproject.toml
collected 18 items

tests/test_api.py ..................                                     [100%]

=============================== warnings summary ===============================
.venv/lib/python3.11/site-packages/vxi11/rpc.py:22
  /home/teddy/repos/python-spd3303x/.venv/lib/python3.11/site-packages/vxi11/rpc.py:22: DeprecationWarning: 'xdrlib' is deprecated and slated for removal in Python 3.13
    import xdrlib

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 18 passed, 1 warning in 4.62s =========================
```

**3.13**
```
============================= test session starts =============================
platform win32 -- Python 3.13.3, pytest-8.4.1, pluggy-1.6.0
rootdir: C:\Users\Teddy\Documents\python-spd3303x
configfile: pyproject.toml
collected 18 items

tests\test_api.py ..................                                     [100%]

============================== warnings summary ===============================
.venv\Lib\site-packages\vxi11\rpc.py:22
  C:\Users\Teddy\Documents\python-spd3303x\.venv\Lib\site-packages\vxi11\rpc.py:22: DeprecationWarning: xdrlib was removed in Python 3.13. Please be aware that you are currently NOT using standard 'xdrlib', but instead a separately installed 'standard-xdrlib'.
    import xdrlib

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 18 passed, 1 warning in 4.63s ========================
```